### PR TITLE
fixed incorrect example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Example using [Compojure-api](https://github.com/metosin/compojure-api) and sett
 (defapi app
   (ring.swagger.ui/swagger-ui
     "/swagger-ui"
-    :api-url "/swagger-docs")
+    :swagger-docs "/swagger-docs")
   (compojure.api.swagger/swagger-docs
     "/swagger-docs"
     :title "Sample Api"


### PR DESCRIPTION
when changing the url for the swagger spec, the correct key to pass to
`swagger-ui` is `:swagger-docs`.