### PR TITLE
Update swagger-ui reference to v2.2.6

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject metosin/ring-swagger-ui "2.2.5-0"
+(defproject metosin/ring-swagger-ui "2.2.6-0"
   :description "Swagger UI for Ring apps"
   :url "https://github.com/metosin/ring-swagger-ui"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
The v2.2.6 includes an important fix for file downloads,
because previous versions showed bytes, instead of triggering a download.