### PR TITLE
Remove source maps

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,15 +5,17 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"
             :distribution :repo
             :comments "same as Clojure"}
+  :plugins [[lein-shell "0.5.0"]]
   :resource {:resource-paths ["ext/swagger-ui/dist" "resources/swagger-ui"
                               "ext/swagger-ui/public" "resources/swagger-ui"]
              :target-path "target/resources/swagger-ui"
-             :skip-stencil [ #".*" ]
-             :includes [#".*/favicon.*\.png"
-                        #".*/swagger-ui\.css.*"
-                        #".*/swagger-ui-.*\.js.*"
+             :skip-stencil [ #".*"]
+             :includes [#".*/favicon.*\.png$"
+                        #".*/swagger-ui\.css$"
+                        #".*/swagger-ui-.*\.js$"
                         #".*/.*\.html"]
              :excludes [#"ext/.*/index\.html"]}
+  :prep-tasks ["resource" ["shell" "bash" "-c" "./remove_sourcemaps.sh"]]
   :resource-paths ["target/resources"]
   :hooks [leiningen.resource]
   :profiles {:dev {:plugins [[lein-resource "17.06.1"]]}})

--- a/remove_sourcemaps.sh
+++ b/remove_sourcemaps.sh
@@ -1,0 +1,6 @@
+echo "Remove source maps"
+sed -i -e '/\/\*# sourceMappingURL.*/d' target/resources/swagger-ui/swagger-ui.css
+sed -i -e '/\/\/# sourceMappingURL.*/d' target/resources/swagger-ui/swagger-ui-bundle.js
+sed -i -e '/\/\/# sourceMappingURL.*/d' target/resources/swagger-ui/swagger-ui-es-bundle-core.js
+sed -i -e '/\/\/# sourceMappingURL.*/d' target/resources/swagger-ui/swagger-ui-es-bundle.js
+sed -i -e '/\/\/# sourceMappingURL.*/d' target/resources/swagger-ui/swagger-ui-standalone-preset.js


### PR DESCRIPTION
This is the first PR that should make ring-swagger-ui closer to GraalVM and AWS Lambda. AWS Lambda has a hard limit for the resource size, therefore map files could not be sent through AWS Api Gateway. I think that the current support for map files is not necessary, and could be successfully removed.

We should think about ring-swagger-ui as a production build of swagger-ui. Production builds in general don't include source maps. 

Issue: https://github.com/metosin/ring-swagger-ui/issues/20