### PR TITLE
Update native-image resource config to json

### DIFF
--- a/resources-graalvm/META-INF/native-image/metosin/ring-swagger-ui/native-image.properties
+++ b/resources-graalvm/META-INF/native-image/metosin/ring-swagger-ui/native-image.properties
@@ -1,1 +1,0 @@
-Args=-H:IncludeResources=swagger-ui/.*

--- a/resources-graalvm/META-INF/native-image/metosin/ring-swagger-ui/resource-config.json
+++ b/resources-graalvm/META-INF/native-image/metosin/ring-swagger-ui/resource-config.json
@@ -1,0 +1,7 @@
+{
+	"resources": {
+		"includes": [{
+			"pattern": "^swagger-ui/.*^"
+		}]
+	}
+}


### PR DESCRIPTION
The current native-image resource config uses the experimental option which causes a warning to be printed (somewhat relevant issue https://github.com/oracle/graal/issues/7354):

```
 1 experimental option(s) unlocked:
 - '-H:IncludeResources' (origin(s): command line)
 ```

Switching the config to a json file should resolve that.